### PR TITLE
Fixing Lemon

### DIFF
--- a/LeGourmetRevolution/media/lua/client/Farming/ISUI/ExtractSeedsMenu.lua
+++ b/LeGourmetRevolution/media/lua/client/Farming/ISUI/ExtractSeedsMenu.lua
@@ -8,7 +8,7 @@ ExtractSeedsMenu.doMenu = function(player, context, items)
         local tempitem = v;
         if not instanceof(v, "InventoryItem") then tempitem = v.items[1]; end
         if tempitem:IsFood() and
-            (tempitem:getFoodType() == "Fruits" or tempitem:getType() ==
+            (tempitem:getFoodType() == "Fruits" or tempitem:getFoodType() == "Citrus" or tempitem:getType() ==
                 "Tomato") and tempitem:IsRotten() then
             if pl:getInventory():contains(tempitem) then
                 Fruit = tempitem


### PR DESCRIPTION
foodtype was citrus not fruits. So added check for citrus, even if another item citrus, wont work beyond initial check.